### PR TITLE
Fix Chrome Version Number Regex Check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,10 @@ class BuildScripts(build_scripts):
         if plat.startswith('darwin'):
             os_ = 'mac'
             # Only 64 bit architecture is available for mac since version 2.23
-            architecture = 64 if float(chromedriver_version) >= 2.23 else 32
+            try:
+                architecture = 64 if float(chromedriver_version) >= 2.23 else 32
+            except ValueError:
+                architecture = 64
         elif plat.startswith('linux'):
             os_ = 'linux'
             architecture = platform.architecture()[0][:-3]

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ CHROMEDRIVER_URL_TEMPLATE = (
     '{architecture}.zip'
 )
 
-CHROMEDRIVER_VERSION_PATTERN = re.compile(r'^\d+\.\d+$')
+CHROMEDRIVER_VERSION_PATTERN = re.compile(r'^\d+\.\d+(.\d+\.\d+){0,1}$')
 CROMEDRIVER_LATEST_VERSION_PATTERN = re.compile(
     r'Latest-Release:-ChromeDriver-(\d+\.\d+)'
 )


### PR DESCRIPTION
Chrome Driver versions have moved from a #.# to a #.#.#.# number format in newer versions. A check in this setup script was throwing an Invalid Chromedriver-version error an exception incorrectly. 

Error:
Exception: Invalid --chromedriver-version=76.0.3809.25! Must match /^\d+\.\d+$/

This change fixes that error.

I've tested the new regex in an online regex checker and it matches both the new version string and the old (i.e. 76.0.3809.25 matches, and 2.47 matches)